### PR TITLE
[BetterMixedSeeds] Fiber drop chance bugfix and Android patch

### DIFF
--- a/BetterMixedSeeds/ModEntry.cs
+++ b/BetterMixedSeeds/ModEntry.cs
@@ -83,10 +83,14 @@ namespace BetterMixedSeeds
                 prefix: new HarmonyMethod(AccessTools.Method(typeof(CropPatch), nameof(CropPatch.RandomCropPrefix)))
             );
 
-            harmony.Patch(
-                original: AccessTools.Method(typeof(StardewValley.Object), "cutWeed"),
-                prefix: new HarmonyMethod(AccessTools.Method(typeof(ObjectPatch), nameof(ObjectPatch.CutWeedPrefix)))
-            );
+            // omit the troublesome cutweeds patch on Android devices
+            if (!(Constants.TargetPlatform == GamePlatform.Android))
+            {
+                harmony.Patch(
+                    original: AccessTools.Method(typeof(StardewValley.Object), "cutWeed"),
+                    prefix: new HarmonyMethod(AccessTools.Method(typeof(ObjectPatch), nameof(ObjectPatch.CutWeedPrefix)))
+                );
+            }
         }
 
         /// <summary>Calculates what seeds should dropped from mixed seeds. This is dependant on the config and installed mods.</summary>

--- a/BetterMixedSeeds/Patches/ObjectPatch.cs
+++ b/BetterMixedSeeds/Patches/ObjectPatch.cs
@@ -26,7 +26,7 @@ namespace BetterMixedSeeds.Patches
                 parentSheetIndex = 771;
             }
 
-            if (Game1.random.NextDouble() < mixedSeedDropChance)
+            else if (Game1.random.NextDouble() < mixedSeedDropChance)
             {
                 parentSheetIndex = 770;
             }


### PR DESCRIPTION
1. I corrected a bug in the way `mixedSeedDropChance` was applied. Previously, fiber drops had a chance of being overwritten by mixed seeds drops, and if `PercentDropChanceForMixedSeedsWhenNotFiber` = 100 no fiber would ever be found.

2. I applied a conditional that will omit one of the harmony patches when running the game on an Android device. This circumvents the bug that broke things on Android, allowing Android users to have full functionality of the mod (except for the `PercentDropChanceForMixedSeedsWhenNotFiber` config which now does nothing on Android). No more need to add and remove the mod when planting mixed seeds!

P.S. Tested on Android (to verify that it works) and on Windows (still works!) 